### PR TITLE
fix sign error for app pay

### DIFF
--- a/src/async_impl/pay.rs
+++ b/src/async_impl/pay.rs
@@ -80,7 +80,7 @@ impl WechatPay {
             .await
             .map(|mut result: AppResponse| {
                 if let Some(prepay_id) = &result.prepay_id {
-                    result.sign_data = Some(self.mut_sign_data("prepay_id=", prepay_id));
+                    result.sign_data = Some(self.mut_sign_data("", prepay_id));
                 }
                 result
             })

--- a/src/blocking/pay.rs
+++ b/src/blocking/pay.rs
@@ -74,7 +74,7 @@ impl WechatPay {
         self.pay(HttpMethod::POST, url, params)
             .map(|mut result: AppResponse| {
                 if let Some(prepay_id) = &result.prepay_id {
-                    result.sign_data = Some(self.mut_sign_data("prepay_id=", prepay_id));
+                    result.sign_data = Some(self.mut_sign_data("", prepay_id));
                 }
                 result
             })


### PR DESCRIPTION
the sign calculation of purchase in App shouldn't include prefix 'prepay_id'. please refer to https://pay.weixin.qq.com/docs/partner/apis/partner-in-app-payment/app-transfer-payment.html#%E8%AF%B7%E6%B1%82%E5%8F%82%E6%95%B0